### PR TITLE
feat: add entry point, Dockerfile, and dockerignore

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.test.ts
+__fixtures__
+.env

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+COPY api/package.json api/package-lock.json ./
+RUN npm ci
+COPY api/tsconfig.json ./
+COPY api/src/ src/
+RUN npx tsc
+
+FROM node:22-slim
+WORKDIR /app
+COPY api/package.json api/package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist/ dist/
+COPY api/config.default.yaml ./
+
+# Copy prompt directories
+COPY academic/ /prompts/academic/
+COPY design/ /prompts/design/
+COPY engineering/ /prompts/engineering/
+COPY game-development/ /prompts/game-development/
+COPY marketing/ /prompts/marketing/
+COPY paid-media/ /prompts/paid-media/
+COPY product/ /prompts/product/
+COPY project-management/ /prompts/project-management/
+COPY sales/ /prompts/sales/
+COPY specialized/ /prompts/specialized/
+COPY support/ /prompts/support/
+COPY spatial-computing/ /prompts/spatial-computing/
+
+ENV PROMPTS_DIR=/prompts
+ENV PORT=3100
+EXPOSE 3100
+
+CMD ["node", "dist/index.js", "rest"]

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,44 @@
+import { serve } from '@hono/node-server';
+import { resolve } from 'path';
+import { loadConfig } from './config.js';
+import { scanPrompts } from './catalog/scanner.js';
+import { Catalog } from './catalog/catalog.js';
+import { ExecutionEngine } from './execution/engine.js';
+import { setLogLevel, log } from './observability/logger.js';
+import { ConsoleMetricsEmitter } from './observability/metrics.js';
+
+const mode = process.argv[2]; // 'rest', 'mcp', or undefined (defaults to rest)
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  setLogLevel(config.log_level);
+
+  const promptsDir = resolve(import.meta.dirname, '..', config.prompts_dir);
+  log('info', 'scanning_prompts', { dir: promptsDir });
+
+  const entries = await scanPrompts(promptsDir);
+  const catalog = new Catalog(entries);
+  log('info', 'catalog_ready', { agents: catalog.count });
+
+  const metrics = new ConsoleMetricsEmitter();
+  const engine = new ExecutionEngine(config.execution, metrics);
+
+  if (mode === 'mcp') {
+    // MCP mode imports dynamically to avoid loading REST deps
+    const { startMcpServer } = await import('./mcp/server.js');
+    log('info', 'starting_mcp_server');
+    await startMcpServer(catalog, engine);
+  } else {
+    // REST mode imports dynamically to avoid loading MCP deps
+    const { createApp } = await import('./rest/app.js');
+    const app = createApp(catalog, engine);
+    log('info', 'starting_rest_server', { port: config.port });
+    serve({ fetch: app.fetch, port: config.port });
+    log('info', 'server_ready', { port: config.port, agents: catalog.count });
+  }
+}
+
+main().catch((err) => {
+  log('error', 'startup_failed', { message: String(err) });
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `api/src/index.ts` entry point supporting `rest` (default) and `mcp` modes via CLI arg
- Add multi-stage `api/Dockerfile` (build context = repo root, copies prompt dirs into `/prompts`)
- Add `api/.dockerignore` excluding node_modules, dist, tests, fixtures, and .env

## Test plan
- [x] All 20 existing unit tests pass (`npx vitest run`)
- [ ] E2E validation after sibling PRs (REST app, MCP server) are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)