### PR TITLE
feat: REST API endpoints (health, agents, execute)

### DIFF
--- a/api/src/rest/agents.test.ts
+++ b/api/src/rest/agents.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentEntry } from '../types.js';
+import { Catalog } from '../catalog/catalog.js';
+import { createApp } from './app.js';
+
+const AGENTS: AgentEntry[] = [
+  {
+    slug: 'code-reviewer',
+    name: 'Code Reviewer',
+    division: 'engineering',
+    specialty: 'Code review and quality',
+    whenToUse: 'When you need a code review',
+    emoji: '🔍',
+    promptPath: 'prompts/code-reviewer.md',
+    promptContent: 'You are a code reviewer.',
+  },
+  {
+    slug: 'writer',
+    name: 'Content Writer',
+    division: 'marketing',
+    specialty: 'Blog posts and copy',
+    whenToUse: 'When you need written content',
+    emoji: '✍️',
+    promptPath: 'prompts/writer.md',
+    promptContent: 'You are a content writer.',
+  },
+  {
+    slug: 'debugger',
+    name: 'Debugger',
+    division: 'engineering',
+    specialty: 'Bug diagnosis',
+    whenToUse: 'When you need to find bugs',
+    emoji: '🐛',
+    promptPath: 'prompts/debugger.md',
+    promptContent: 'You are a debugger.',
+  },
+];
+
+function makeApp() {
+  const catalog = new Catalog(AGENTS);
+  return createApp(catalog, null as any);
+}
+
+describe('GET /v1/agents', () => {
+  it('lists all agents with pagination', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.version).toBe('v1');
+    expect(body.total).toBe(3);
+    expect(body.agents).toHaveLength(3);
+    expect(body.limit).toBe(20);
+    expect(body.offset).toBe(0);
+  });
+
+  it('filters by division', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents?division=engineering');
+    const body = await res.json();
+
+    expect(body.total).toBe(2);
+    expect(body.agents.every((a: any) => a.division === 'engineering')).toBe(true);
+  });
+
+  it('searches by query string', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents?q=bug');
+    const body = await res.json();
+
+    expect(body.total).toBe(1);
+    expect(body.agents[0].slug).toBe('debugger');
+  });
+
+  it('paginates with limit and offset', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents?limit=1&offset=1');
+    const body = await res.json();
+
+    expect(body.total).toBe(3);
+    expect(body.agents).toHaveLength(1);
+    expect(body.limit).toBe(1);
+    expect(body.offset).toBe(1);
+  });
+
+  it('does not include prompt content in list', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents');
+    const body = await res.json();
+
+    for (const agent of body.agents) {
+      expect(agent).not.toHaveProperty('promptContent');
+      expect(agent).not.toHaveProperty('prompt');
+      expect(agent).not.toHaveProperty('promptPath');
+    }
+  });
+});
+
+describe('GET /v1/agents/:slug', () => {
+  it('returns agent detail with prompt', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents/code-reviewer');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.version).toBe('v1');
+    expect(body.agent.slug).toBe('code-reviewer');
+    expect(body.agent.prompt).toBe('You are a code reviewer.');
+    expect(body.agent.name).toBe('Code Reviewer');
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/agents/nonexistent');
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe('AGENT_NOT_FOUND');
+  });
+});

--- a/api/src/rest/agents.ts
+++ b/api/src/rest/agents.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono';
+import { AgentApiError } from '../types.js';
+import type { Catalog } from '../catalog/catalog.js';
+
+export function agentRoutes(catalog: Catalog) {
+  const router = new Hono();
+
+  router.get('/v1/agents', (c) => {
+    const division = c.req.query('division');
+    const q = c.req.query('q');
+    const limit = Math.min(
+      Math.max(parseInt(c.req.query('limit') ?? '20', 10) || 20, 1),
+      100,
+    );
+    const offset = Math.max(
+      parseInt(c.req.query('offset') ?? '0', 10) || 0,
+      0,
+    );
+
+    const result = catalog.list({ division, q, limit, offset });
+
+    return c.json({
+      version: 'v1',
+      ...result,
+    });
+  });
+
+  router.get('/v1/agents/:slug', (c) => {
+    const slug = c.req.param('slug');
+    const agent = catalog.get(slug);
+
+    if (!agent) {
+      throw new AgentApiError('AGENT_NOT_FOUND', 404, `Agent '${slug}' not found`);
+    }
+
+    return c.json({
+      version: 'v1',
+      agent: {
+        slug: agent.slug,
+        name: agent.name,
+        division: agent.division,
+        specialty: agent.specialty,
+        whenToUse: agent.whenToUse,
+        emoji: agent.emoji,
+        prompt: agent.promptContent,
+      },
+    });
+  });
+
+  return router;
+}

--- a/api/src/rest/app.ts
+++ b/api/src/rest/app.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { errorHandler } from './error-handler.js';
+import { healthRoutes } from './health.js';
+import { agentRoutes } from './agents.js';
+import { executeRoutes } from './execute.js';
+import type { Catalog } from '../catalog/catalog.js';
+import type { ExecutionEngine } from '../execution/engine.js';
+
+export function createApp(catalog: Catalog, engine: ExecutionEngine): Hono {
+  const app = new Hono();
+
+  app.use('*', cors());
+  app.onError(errorHandler);
+
+  app.route('', healthRoutes(catalog));
+  app.route('', agentRoutes(catalog));
+  app.route('', executeRoutes(catalog, engine));
+
+  return app;
+}

--- a/api/src/rest/error-handler.ts
+++ b/api/src/rest/error-handler.ts
@@ -1,0 +1,13 @@
+import type { Context } from 'hono';
+import { AgentApiError } from '../types.js';
+
+export function errorHandler(err: Error, c: Context): Response {
+  if (err instanceof AgentApiError) {
+    return c.json(err.toJSON(), err.statusCode as 400 | 404 | 422 | 500);
+  }
+
+  return c.json(
+    { error: { code: 'INTERNAL_ERROR', message: err.message, details: {} } },
+    500,
+  );
+}

--- a/api/src/rest/execute.test.ts
+++ b/api/src/rest/execute.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AgentEntry, ExecutionResult } from '../types.js';
+import { Catalog } from '../catalog/catalog.js';
+import { createApp } from './app.js';
+
+const AGENT: AgentEntry = {
+  slug: 'test-agent',
+  name: 'Test Agent',
+  division: 'engineering',
+  specialty: 'testing',
+  whenToUse: 'When you need tests',
+  emoji: '🧪',
+  promptPath: 'prompts/test.md',
+  promptContent: 'You are a test agent.',
+};
+
+const MOCK_SUMMARY: ExecutionResult = {
+  version: 'v1',
+  agent: 'test-agent',
+  task: 'say hello',
+  result: { greeting: 'Hello!' },
+  metadata: {
+    model: 'claude-sonnet-4-20250514',
+    tokens_in: 10,
+    tokens_out: 5,
+    duration_ms: 100,
+    execution_id: 'exec_test',
+  },
+};
+
+function createMockEngine() {
+  return {
+    async *executeStream() {
+      yield { type: 'token' as const, data: 'Hello ' };
+      yield { type: 'token' as const, data: 'world!' };
+      yield { type: 'summary' as const, data: MOCK_SUMMARY };
+    },
+    buildSystemPrompt: vi.fn(),
+    resolveModel: vi.fn(),
+    resolveMaxTokens: vi.fn(),
+    execute: vi.fn(),
+  };
+}
+
+function makeApp(engine = createMockEngine()) {
+  const catalog = new Catalog([AGENT]);
+  return createApp(catalog, engine as any);
+}
+
+describe('POST /v1/agents/:slug/execute', () => {
+  it('streams SSE events for a valid request', async () => {
+    const app = makeApp();
+
+    const res = await app.request('/v1/agents/test-agent/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task: 'say hello' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const text = await res.text();
+    expect(text).toContain('event: token');
+    expect(text).toContain('data: Hello ');
+    expect(text).toContain('event: summary');
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    const app = makeApp();
+
+    const res = await app.request('/v1/agents/nonexistent/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task: 'hello' }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('AGENT_NOT_FOUND');
+  });
+
+  it('returns 422 when task is missing', async () => {
+    const app = makeApp();
+
+    const res = await app.request('/v1/agents/test-agent/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 422 when task is empty string', async () => {
+    const app = makeApp();
+
+    const res = await app.request('/v1/agents/test-agent/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task: '   ' }),
+    });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('streams error events from engine', async () => {
+    const errorEngine = {
+      async *executeStream() {
+        yield { type: 'error' as const, data: { code: 'MODEL_ERROR', message: 'Rate limited', details: {} } };
+      },
+      buildSystemPrompt: vi.fn(),
+      resolveModel: vi.fn(),
+      resolveMaxTokens: vi.fn(),
+      execute: vi.fn(),
+    };
+
+    const app = makeApp(errorEngine);
+
+    const res = await app.request('/v1/agents/test-agent/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task: 'fail please' }),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('event: error');
+    expect(text).toContain('MODEL_ERROR');
+  });
+});

--- a/api/src/rest/execute.ts
+++ b/api/src/rest/execute.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import { AgentApiError } from '../types.js';
+import type { Catalog } from '../catalog/catalog.js';
+import type { ExecutionEngine } from '../execution/engine.js';
+
+export function executeRoutes(catalog: Catalog, engine: ExecutionEngine) {
+  const router = new Hono();
+
+  router.post('/v1/agents/:slug/execute', async (c) => {
+    const slug = c.req.param('slug');
+    const agent = catalog.get(slug);
+
+    if (!agent) {
+      throw new AgentApiError('AGENT_NOT_FOUND', 404, `Agent '${slug}' not found`);
+    }
+
+    const body = await c.req.json().catch(() => null);
+
+    if (!body || typeof body.task !== 'string' || !body.task.trim()) {
+      throw new AgentApiError('VALIDATION_ERROR', 422, 'Field "task" is required and must be a non-empty string');
+    }
+
+    const { task, context, model } = body;
+
+    return streamSSE(c, async (stream) => {
+      for await (const event of engine.executeStream(agent, task, context, model)) {
+        await stream.writeSSE({
+          event: event.type,
+          data: typeof event.data === 'string' ? event.data : JSON.stringify(event.data),
+        });
+      }
+    });
+  });
+
+  return router;
+}

--- a/api/src/rest/health.test.ts
+++ b/api/src/rest/health.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentEntry } from '../types.js';
+import { Catalog } from '../catalog/catalog.js';
+import { createApp } from './app.js';
+
+const AGENT: AgentEntry = {
+  slug: 'test-agent',
+  name: 'Test Agent',
+  division: 'engineering',
+  specialty: 'testing',
+  whenToUse: 'When you need tests',
+  emoji: '🧪',
+  promptPath: 'prompts/test.md',
+  promptContent: 'You are a test agent.',
+};
+
+describe('GET /v1/health', () => {
+  it('returns status ok with agent count', async () => {
+    const catalog = new Catalog([AGENT]);
+    const app = createApp(catalog, null as any);
+
+    const res = await app.request('/v1/health');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      version: 'v1',
+      status: 'ok',
+      agents_loaded: 1,
+    });
+  });
+
+  it('returns 0 agents when catalog is empty', async () => {
+    const catalog = new Catalog([]);
+    const app = createApp(catalog, null as any);
+
+    const res = await app.request('/v1/health');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.agents_loaded).toBe(0);
+  });
+});

--- a/api/src/rest/health.ts
+++ b/api/src/rest/health.ts
@@ -1,0 +1,16 @@
+import { Hono } from 'hono';
+import type { Catalog } from '../catalog/catalog.js';
+
+export function healthRoutes(catalog: Catalog) {
+  const router = new Hono();
+
+  router.get('/v1/health', (c) => {
+    return c.json({
+      version: 'v1',
+      status: 'ok',
+      agents_loaded: catalog.count,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Adds all v1 REST endpoints: health check, agent listing with filter/search/pagination, agent detail with prompt, and SSE streaming execution
- Unified error handler maps `AgentApiError` to structured JSON responses
- Full test coverage: 14 tests across health, agents, and execute modules (all passing)

## Test plan
- [x] `npx vitest run` passes all 34 tests (14 new + 20 existing)
- [ ] e2e testing deferred to post-merge integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)